### PR TITLE
Map strings are now stored and loaded from the URL 

### DIFF
--- a/src/editors/map-editor.js
+++ b/src/editors/map-editor.js
@@ -26,6 +26,36 @@ import {
 window.jQuery = $;
 const LOOPS_TO_TRY = 10000;
 
+/// Load a map string from the #STRING url parameter, or the empty string
+/// if there is no such 
+const load_initial_map_string = () => {
+    const url = new URL(window.location.href);
+    const hash = url.hash;
+    const match = hash.match(/^#?(\d+(?:-\d+)*)$/);
+
+    if(!match) {
+        return ""
+    }
+
+    const map_string = match[1];
+    const components = map_string.split('-');
+
+    // Ensure that each component is an int
+    if (!components.every(c => /^\d+/.test(c))) {
+        return "";
+    }
+
+    return components.join(" ");
+}
+
+/// Add the map string to the URL
+const set_map_string_url = map_string => {
+    const encoded = map_string.trim().split(/\s+/).join("-");
+    const url = new URL(window.location.href);
+    url.hash = encoded;
+    window.location.href = url;
+}
+
 export class MapEditor extends BaseEditor {
     constructor(props) {
         super(props);
@@ -60,6 +90,13 @@ export class MapEditor extends BaseEditor {
         }
     }
 
+    componentDidMount() {
+        const initial_map_string = load_initial_map_string();
+        if(initial_map_string) {
+            this.loadMapFromString(initial_map_string)
+        }
+    }
+
     setMap(new_map, home_values=null, balance_difference=null, eval_var=null) {
         if(new_map.isComplete()) {
             if(home_values===null) {
@@ -73,13 +110,16 @@ export class MapEditor extends BaseEditor {
             home_values = {};
             balance_difference = null;
         }
+        const map_string = this.getMapString(new_map);
+
         this.setState({
             "map": new_map,
             "bank_systems": this.syncBankSystems(new_map),
             "home_values": home_values,
             "balance_difference": balance_difference,
-            "map_string": this.getMapString(new_map),
+            "map_string": map_string,
         });
+        set_map_string_url(map_string);
     }
 
     syncBankSystems(map, include_expansion_systems=null, include_base_systems=null) {
@@ -804,14 +844,12 @@ export class MapEditor extends BaseEditor {
                                         type="text"
                                         id="layout-title"
                                         value={this.state.input_title}
-                                        onChange={function() {
-                                            this.setState(
-                                                {
-                                                    "input_title": document.getElementById("layout-title").value,
-                                                    "message": ""
-                                                }
-                                            );
-                                        }.bind(this)}
+                                        onChange={event => {
+                                            this.setState({
+                                                "input_title": event.target.value,
+                                                "message": ""
+                                            });
+                                        }}
                                     />
                                 </p>
                                 <p className="control">
@@ -882,14 +920,12 @@ export class MapEditor extends BaseEditor {
                                         type="text"
                                         id="map-string"
                                         value={this.state.map_string}
-                                        onChange={function() {
-                                            this.setState(
-                                                {
-                                                    "map_string": document.getElementById("map-string").value,
-                                                    "message": ""
-                                                }
-                                            );
-                                        }.bind(this)}
+                                        onChange={event => {
+                                            this.setState({
+                                                "map_string": event.target.value,
+                                                "message": ""
+                                            });
+                                        }}
                                     />
                                 </p>
                                 <p className="control">

--- a/src/map-logic.js
+++ b/src/map-logic.js
@@ -628,40 +628,34 @@ export class Map {
     }
 
     isComplete() {
-        for(let map_space of this.spaces) {
-            if(map_space.type===MAP_SPACE_TYPES.OPEN) {
-                return false;
-            }
-        }
-        return true;
+        return this.spaces.every(map_space => map_space.type !== MAP_SPACE_TYPES.OPEN)
     }
 	
 	getTotalOpen() {
 		return this.spaces.filter(space=>space.type===MAP_SPACE_TYPES.OPEN).length
 	}
 
+    // The map is legal if:
+    // - there are no adjacent matching wormholes
+    // - there are no adjacent anomalies
     isLegal() {
-        let is_legal = true;
         for(let map_space of this.spaces) {
             if(map_space.type===MAP_SPACE_TYPES.SYSTEM && map_space.system.wormhole !== null) {
                 for(let one_sys of this.getAdjacentSystems(map_space)) {
                     if(one_sys.type===MAP_SPACE_TYPES.SYSTEM && one_sys.system.wormhole===map_space.system.wormhole) {
-                        is_legal = false;
-                        break;
+                        return false;
                     }
                 }
             }
             if(map_space.type===MAP_SPACE_TYPES.SYSTEM && map_space.system.anomaly !== null) {
                 for(let one_sys of this.getAdjacentSystems(map_space)) {
                     if(one_sys.type===MAP_SPACE_TYPES.SYSTEM && one_sys.system.anomaly!==null) {
-                        is_legal = false;
-                        break;
+                        return false;
                     }
                 }
             }
-            if(!is_legal) break;
         }
-        return is_legal;
+        return true;
     }
 
     getHomeValue(space, variables) {


### PR DESCRIPTION
This PR makes it so that changes to the map are reflected in the hash parameter of the URL, and so that when the site is loaded, the map is initially populated from this part of the URL. This makes it easy to share maps via URL with other players.

Additionally adds some minor logic simplifications to `map-logic.js`

Example URL: https://joepinion.github.io/ti4-map-lab/#35-29-45-32-33-76-21-78-68-73-69-59-75-48-60-41-19-79-0-28-63-0-66-44-0-64-43-0-67-39-0-72-23-0-20-40